### PR TITLE
Updates tabula version to latest 1.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk
 
-ENV TABULA_VERSION 1.1.1
+ENV TABULA_VERSION 1.2.1
 
 RUN wget -q https://github.com/tabulapdf/tabula/releases/download/v$TABULA_VERSION/tabula-jar-$TABULA_VERSION.zip && \
     unzip tabula-jar-$TABULA_VERSION.zip && \

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Matt ‘TK’ Taylor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Run from [Docker Hub](https://hub.docker.com/)
 
 ```
-docker run -d -p 8080:8080 mtaylor/tabula
+docker run -d -p 8080:8080 mtaylor/tabula-docker
 ```
 
 Now open your browser to http://localhost:8080/
@@ -18,14 +18,14 @@ You may wish to tweak the `docker run` command above in order to...
 
   ```
   # Example: v0.9.3
-  docker run -d -p 8080:8080 mtaylor/tabula:0.9.3
+  docker run -d -p 8080:8080 mtaylor/tabula-docker:0.9.3
   ```
 
 - listen on a different port
 
   ```
   # Example: port 8100
-  docker run -d -p 8100:8080 mtaylor/tabula
+  docker run -d -p 8100:8080 mtaylor/tabula-docker
   ```
 
   Access the web interface at http://localhost:8100/
@@ -33,14 +33,14 @@ You may wish to tweak the `docker run` command above in order to...
 - follow the logs while the container runs
 
   ```
-  docker run -p 8080:8080 mtaylor/tabula
+  docker run -p 8080:8080 mtaylor/tabula-docker
   ```
 
 You may find more options in the official [documentation](https://docs.docker.com/engine/reference/commandline/run/)
 
 ## Build your own image
 
-Instead of pulling a pre-built container image from [mtaylor/tabula](https://hub.docker.com/r/mtaylor/tabula/), you may build your own using the Dockerfile in this repo:
+Instead of pulling a pre-built container image from [mtaylor/tabula-docker](https://hub.docker.com/r/mtaylor/tabula-docker), you may build your own using the Dockerfile in this repo:
 
 ```
 git clone git@github.com:mattietk/tabula-docker.git

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Run from [Docker Hub](https://hub.docker.com/)
 
 ```
-docker run -d -p 8080:8080 asnelling/tabula
+docker run -d -p 8080:8080 mtaylor/tabula
 ```
 
 Now open your browser to http://localhost:8080/
@@ -18,14 +18,14 @@ You may wish to tweak the `docker run` command above in order to...
 
   ```
   # Example: v0.9.3
-  docker run -d -p 8080:8080 asnelling/tabula:0.9.3
+  docker run -d -p 8080:8080 mtaylor/tabula:0.9.3
   ```
 
 - listen on a different port
 
   ```
   # Example: port 8100
-  docker run -d -p 8100:8080 asnelling/tabula
+  docker run -d -p 8100:8080 mtaylor/tabula
   ```
 
   Access the web interface at http://localhost:8100/
@@ -33,17 +33,17 @@ You may wish to tweak the `docker run` command above in order to...
 - follow the logs while the container runs
 
   ```
-  docker run -p 8080:8080 asnelling/tabula
+  docker run -p 8080:8080 mtaylor/tabula
   ```
 
 You may find more options in the official [documentation](https://docs.docker.com/engine/reference/commandline/run/)
 
 ## Build your own image
 
-Instead of pulling a pre-built container image from [asnelling/tabula](https://hub.docker.com/r/asnelling/tabula/), you may build your own using the Dockerfile in this repo:
+Instead of pulling a pre-built container image from [mtaylor/tabula](https://hub.docker.com/r/mtaylor/tabula/), you may build your own using the Dockerfile in this repo:
 
 ```
-git clone git@github.com:asnelling/tabula-docker.git
+git clone git@github.com:mattietk/tabula-docker.git
 docker build -t mytabula tabula-docker
 docker run -d -p 8080:8080 mytabula
 ```


### PR DESCRIPTION
Tabula is up to 1.2.1 - this image works just by modifying the version number, so it would be great to put a new release out.

Thanks